### PR TITLE
修正对于CRAC Logo的描述

### DIFF
--- a/docs/HamCQ手册/02.走进业余无线电/04.开始通联/01.基本知识/07.QSL卡片.md
+++ b/docs/HamCQ手册/02.走进业余无线电/04.开始通联/01.基本知识/07.QSL卡片.md
@@ -22,7 +22,6 @@ QSL卡片是通联的证明。关于QSL卡片介绍，可阅读《业余无线�
 * 日期DATE、时间TIME
 * 频率FREQ、模式MODE
 * 你的电台、天线、发射功率
-* CRAC的logo，表示国籍，高清素材可从[官方网站](http://www.crac.org.cn/News/Detail?ID=327)下载
 
 如果还不确定，可直接参考现成模板设计，例如[BI3AR的模板](https://forum.hamcq.cn/d/418)。
 


### PR DESCRIPTION
QSL卡片并没有必须要使用CRAC/CRSA Logo的理由